### PR TITLE
Make instructions a little more prominent

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,7 +180,11 @@ ENTRYPOINT ["java", "-jar", "storm-tracker.jar" ]
    ```
 	./mvnw package docker:build -Ddocker.username=iamapikey -Ddocker.password=<your api-key> docker:push 
    ```
-	**Note:** If you are getting an issue where adoptopenjdk/openjdk8-openj9:alpine-slim is not being pulled run `docker pull adoptopenjdk/openjdk8-openj9:alpine-slim` first before the above command. 
+	**Note:** If you are getting an issue where adoptopenjdk/openjdk8-openj9:alpine-slim is not being pulled run:
+    ```bash
+    docker pull adoptopenjdk/openjdk8-openj9:alpine-slim
+    ```
+    first before the above command. 
 	**Note:** You will use the api key in the file we created at the end of the [Configure IBM Cloud](#configure-ibm-cloud). Be sure to use the value **iampikey** for the username.
 
    You should see output that looks like the following near the end of the build execution:


### PR DESCRIPTION
Breaks the bash command for `docker pull` out on to a separate line